### PR TITLE
feat: mapping uses individual endpoints to discover other classes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder
             ->getRootNode()
             ->children()
-            ->scalarNode('default_class_namespace')->isRequired()->end()
+            ->scalarNode('default_class_namespace')->setDeprecated()->end()
             ->arrayNode('mappings')
                 ->beforeNormalization()
                     ->ifArray()

--- a/DependencyInjection/JsonLDClientExtension.php
+++ b/DependencyInjection/JsonLDClientExtension.php
@@ -33,13 +33,8 @@ class JsonLDClientExtension extends Extension
         $container->register(MappingCollection::class, MappingCollection::class)
             ->setFactory(array(MappingCollection::class, 'create'))
             ->addArgument($config['mappings'])
-            ->addArgument($config['default_class_namespace'])
             ->setPublic(false);
 
-        $container->setParameter(
-            "{$this->getAlias()}.default_class_namespace",
-            $config['default_class_namespace']
-        );
 
         $loader = new YamlFileLoader(
             $container,

--- a/Mapping/MappingCollection.php
+++ b/Mapping/MappingCollection.php
@@ -6,12 +6,10 @@ use Bookboon\JsonLDClient\Client\JsonLDException;
 
 class MappingCollection
 {
-    protected string  $defaultNamespace;
-
     /** @var array<MappingEndpoint> */
     protected array $mappings;
 
-    public function __construct(array $mappings, string $defaultNamespace = 'App\\Entity')
+    public function __construct(array $mappings)
     {
         foreach ($mappings as $map) {
             if (!($map instanceof MappingEndpoint)) {
@@ -19,11 +17,10 @@ class MappingCollection
             }
         }
 
-        $this->defaultNamespace = rtrim($defaultNamespace, '\\');
         $this->mappings = $mappings;
     }
 
-    public static function create(array $mappings, string $defaultNamespace = 'App\\Entity') : MappingCollection
+    public static function create(array $mappings) : MappingCollection
     {
         $endpoints = [];
 
@@ -36,13 +33,10 @@ class MappingCollection
                 throw new MappingException('Invalid uri');
             }
 
-            $endpoints[] = new MappingEndpoint(
-                strpos($map['type'], "\\") === false ? "$defaultNamespace\\{$map['type']}" : $map['type'],
-                $map['uri'],
-                $map['renamed_properties'] ?? [],
-            );
+            $endpoints[] = new MappingEndpoint($map['type'], $map['uri'], $map['renamed_properties'] ?? []);
         }
-        return new self($endpoints, $defaultNamespace);
+
+        return new self($endpoints);
     }
 
     /**
@@ -51,14 +45,6 @@ class MappingCollection
     public function get() : array
     {
         return $this->mappings;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaultNamespace(): string
-    {
-        return $this->defaultNamespace;
     }
 
     public function findEndpointByClass(string $className) : MappingEndpoint
@@ -76,7 +62,7 @@ class MappingCollection
      * @param string $shortClass
      * @return string
      */
-    public function findClassByShortNameOrDefault(string $shortClass) : string
+    public function findClassByShortNameOrDefault(string $shortClass, string $defaultNamespace) : string
     {
         if (in_array($shortClass, ['ApiError', 'ApiSource', 'ApiErrorResponse'], true)) {
             return "Bookboon\JsonLDClient\Models\\$shortClass";
@@ -88,6 +74,6 @@ class MappingCollection
             }
         }
 
-        return $this->getDefaultNamespace() . '\\' . $shortClass;
+        return $defaultNamespace . '\\' . $shortClass;
     }
 }

--- a/Mapping/MappingEndpoint.php
+++ b/Mapping/MappingEndpoint.php
@@ -107,6 +107,15 @@ class MappingEndpoint
         return $data;
     }
 
+    public function getClassNamespace() : string
+    {
+        if ($pos = strrpos($this->type, '\\')) {
+            return substr($this->type, 0, $pos);
+        }
+
+        return '';
+    }
+
     protected function endsWith(string $haystack, string $needle): bool
     {
         return substr($haystack, -strlen($needle)) === $needle;

--- a/Serializer/JsonLDNormalizer.php
+++ b/Serializer/JsonLDNormalizer.php
@@ -5,6 +5,7 @@ namespace Bookboon\JsonLDClient\Serializer;
 use Bookboon\JsonLDClient\Client\JsonLDException;
 use Bookboon\JsonLDClient\Client\JsonLDSerializationException;
 use Bookboon\JsonLDClient\Mapping\MappingCollection;
+use Bookboon\JsonLDClient\Mapping\MappingEndpoint;
 use Bookboon\JsonLDClient\Models\ApiError;
 use Bookboon\JsonLDClient\Models\ApiErrorResponse;
 use Bookboon\JsonLDClient\Models\ApiSource;
@@ -15,6 +16,8 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class JsonLDNormalizer implements ContextAwareDenormalizerInterface, ContextAwareNormalizerInterface
 {
+    public const MAPPPING_KEY = 'endpoint';
+
     private MappingCollection $collection;
     private ObjectNormalizer $normalizer;
     private JsonLDCircularReferenceHandler $circularReferenceHandler;
@@ -108,7 +111,13 @@ class JsonLDNormalizer implements ContextAwareDenormalizerInterface, ContextAwar
         }
 
         $attemptType = $data['@type'];
-        $class = $this->collection->findClassByShortNameOrDefault($attemptType);
+        $defaultNamespace = '';
+        $map = $context[self::MAPPPING_KEY] ?? null;
+        if ($map instanceof MappingEndpoint) {
+            $defaultNamespace = $map->getClassNamespace();
+        }
+
+        $class = $this->collection->findClassByShortNameOrDefault($attemptType, $defaultNamespace);
 
         if (false === class_exists($class)) {
             throw new JsonLDSerializationException('Cannot find class: ' . $attemptType, 0, null);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -37,16 +37,12 @@ class ConfigurationTest extends TestCase
             [
                 'jsonldclient' => [
                     'mappings' => [
-                        'Class' => 'https://test'
-                    ],
-                    'default_class_namespace' => 'TestApp\\Entity'
+                        'TestApp\\Entity\\Class' => 'https://test'
+                    ]
                 ]
             ],
             $container = $this->getContainer()
         );
-
-        self::assertTrue($container->hasParameter($this->root . ".default_class_namespace"));
-        self::assertEquals("TestApp\\Entity", $container->getParameter($this->root . ".default_class_namespace"));
 
         $expected = [
             new MappingEndpoint('TestApp\\Entity\\Class', 'https://test')
@@ -65,8 +61,7 @@ class ConfigurationTest extends TestCase
                 'jsonldclient' => [
                     'mappings' => [
                         'OtherApp\\Entity\\Class' => 'https://test'
-                    ],
-                    'default_class_namespace' => 'TestApp\\Entity'
+                    ]
                 ]
             ],
             $container = $this->getContainer()
@@ -89,11 +84,10 @@ class ConfigurationTest extends TestCase
                 'jsonldclient' => [
                     'mappings' => [
                         [
-                            'type' => 'Class',
+                            'type' => 'TestApp\\Entity\\Class',
                             'uri' => 'https://test'
                         ]
-                    ],
-                    'default_class_namespace' => 'TestApp\\Entity'
+                    ]
                 ]
             ],
             $container = $this->getContainer()
@@ -116,10 +110,9 @@ class ConfigurationTest extends TestCase
                 'jsonldclient' => [
                     'mappings' => [
                         [
-                            'type' => 'Class'
+                            'type' => 'TestApp\\Entity\\Class'
                         ]
-                    ],
-                    'default_class_namespace' => 'TestApp\\Entity'
+                    ]
                 ]
             ],
             $container = $this->getContainer()

--- a/Tests/Fixtures/Builder.php
+++ b/Tests/Fixtures/Builder.php
@@ -16,14 +16,13 @@ class Builder
         $this->extention = $this->getExtension();
     }
 
-    public function get(array $mapping, string $default_class_namespace) : ContainerBuilder
+    public function get(array $mapping) : ContainerBuilder
     {
 
         $this->extention->load(
             [
                 'jsonldclient' => [
-                    'mappings' => $mapping,
-                    'default_class_namespace' => $default_class_namespace
+                    'mappings' => $mapping
                 ]
             ],
             $this->container

--- a/Tests/Fixtures/OtherModels/NestedArrayClass.php
+++ b/Tests/Fixtures/OtherModels/NestedArrayClass.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Bookboon\JsonLDClient\Tests\Fixtures\OtherModels;
+
+
+class NestedArrayClass
+{
+    protected string $string = '';
+    protected array $simpleClasses = [];
+
+    /**
+     * @return string
+     */
+    public function getString() : string
+    {
+        return $this->string;
+    }
+
+    /**
+     * @param string $string
+     * @return void
+     */
+    public function setString(string $string): void
+    {
+        $this->string = $string;
+    }
+
+    /**
+     * @return SimpleClass[]
+     */
+    public function getSimpleClasses() : array
+    {
+        return $this->simpleClasses;
+    }
+
+    /**
+     * @param SimpleClass[] $simpleClasses
+     * @return void
+     */
+    public function setSimpleClasses(array $simpleClasses): void
+    {
+        $this->simpleClasses = $simpleClasses;
+    }
+}

--- a/Tests/Fixtures/OtherModels/SimpleClass.php
+++ b/Tests/Fixtures/OtherModels/SimpleClass.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Bookboon\JsonLDClient\Tests\Fixtures\OtherModels;
+
+
+class SimpleClass
+{
+    protected string $value = '';
+
+    /**
+     * @return string
+     */
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     * return @void
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    public function getId() : string
+    {
+        return '232d2c41-278a-4377-bd9d-c6046494ceaf';
+    }
+}

--- a/Tests/Fixtures/SerializerHelper.php
+++ b/Tests/Fixtures/SerializerHelper.php
@@ -34,7 +34,7 @@ class SerializerHelper
 
         $propertyAccessor = new PropertyAccessor();
 
-        $collection = new MappingCollection($mappings, 'Bookboon\JsonLDClient\Tests\Fixtures\Models');
+        $collection = new MappingCollection($mappings);
         $normalizer = new ObjectNormalizer(null, null, $propertyAccessor, $propertyExtractor, null, null, $defaultContext);
         $serializer = new Serializer(
             [

--- a/Tests/Mapping/MappingCollectionTest.php
+++ b/Tests/Mapping/MappingCollectionTest.php
@@ -17,7 +17,7 @@ class MappingCollectionTest extends TestCase
         $collection = MappingCollection::create(
             [
                 [
-                    'type' => 'Test',
+                    'type' => 'App\Entity\Test',
                     'uri' => 'http://',
                 ]
             ]
@@ -92,13 +92,13 @@ class MappingCollectionTest extends TestCase
     public function testFindClassByShortNameOrDefault_ApiErrorResponse() : void
     {
         $collection = new MappingCollection([]);
-        self::assertEquals(ApiErrorResponse::class, $collection->findClassByShortNameOrDefault('ApiErrorResponse'));
+        self::assertEquals(ApiErrorResponse::class, $collection->findClassByShortNameOrDefault('ApiErrorResponse', 'Bookboon\JsonLDClient'));
     }
 
     public function testFindClassByShortNameOrDefault_ApiError() : void
     {
         $collection = new MappingCollection([]);
-        self::assertEquals(ApiError::class, $collection->findClassByShortNameOrDefault('ApiError'));
+        self::assertEquals(ApiError::class, $collection->findClassByShortNameOrDefault('ApiError', 'Bookboon\JsonLDClient'));
     }
 
     public function testFindClassByShortNameOrDefault_SimpleClass() : void
@@ -107,6 +107,6 @@ class MappingCollectionTest extends TestCase
             new MappingEndpoint(SimpleClass::class, 'http://test')
         ]);
 
-        self::assertEquals(SimpleClass::class, $collection->findClassByShortNameOrDefault('SimpleClass'));
+        self::assertEquals(SimpleClass::class, $collection->findClassByShortNameOrDefault('SimpleClass', 'Bookboon\JsonLDClient\Tests\Fixtures'));
     }
 }

--- a/Tests/Serializer/JsonLDNormalizerTest.php
+++ b/Tests/Serializer/JsonLDNormalizerTest.php
@@ -6,6 +6,7 @@ use Bookboon\JsonLDClient\Client\JsonLDException;
 use Bookboon\JsonLDClient\Client\JsonLDSerializationException;
 use Bookboon\JsonLDClient\Mapping\MappingEndpoint;
 use Bookboon\JsonLDClient\Serializer\JsonLDEncoder;
+use Bookboon\JsonLDClient\Serializer\JsonLDNormalizer;
 use Bookboon\JsonLDClient\Tests\Fixtures\Models\CircularChild;
 use Bookboon\JsonLDClient\Tests\Fixtures\Models\CircularParent;
 use Bookboon\JsonLDClient\Tests\Fixtures\Models\CircularParentWithId;
@@ -32,7 +33,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(SimpleClass::class)
+        );
 
         self::assertInstanceOf(SimpleClass::class, $object);
         self::assertEquals("some random string", $object->getValue());
@@ -71,7 +77,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(DatedClass::class)
+        );
 
         self::assertInstanceOf(DatedClass::class, $object);
         self::assertEquals($date, $object->getCreated());
@@ -87,7 +98,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(DatedClass::class)
+        );
 
         self::assertInstanceOf(DatedClass::class, $object);
         self::assertNull($object->getCreated());
@@ -107,8 +123,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
-
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(NestedClass::class)
+        );
         self::assertInstanceOf(NestedClass::class, $object);
         self::assertEquals("some random string", $object->getString());
 
@@ -132,7 +152,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(NestedClassWithoutDoc::class)
+        );
 
         self::assertInstanceOf(NestedClassWithoutDoc::class, $object);
         self::assertEquals("some random string", $object->getString());
@@ -163,7 +188,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(NestedArrayClass::class)
+        );
 
         self::assertInstanceOf(NestedArrayClass::class, $object);
         self::assertEquals("some random string", $object->getString());
@@ -185,8 +215,13 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $object = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
-
+        $object = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(NestedArrayClass::class)
+        );
+        
         self::assertInstanceOf(NestedArrayClass::class, $object);
         self::assertEquals("some random string", $object->getString());
         self::assertIsArray($object->getSimpleClasses());
@@ -209,7 +244,12 @@ class JsonLDNormalizerTest extends TestCase
         ]
         JSON;
 
-        $objects = $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $objects = $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(SimpleClass::class)
+        );
 
         self::assertIsArray($objects);
         self::assertCount(2, $objects);
@@ -302,7 +342,12 @@ class JsonLDNormalizerTest extends TestCase
         }
         JSON;
 
-        $serializer->deserialize($testJson, '', JsonLDEncoder::FORMAT);
+        $serializer->deserialize(
+            $testJson,
+            '',
+            JsonLDEncoder::FORMAT,
+            $this->getContextWithMapping(NestedClass::class)
+        );
     }
 
     public function testNestedNormalizeMissingClassException() : void
@@ -359,5 +404,12 @@ class JsonLDNormalizerTest extends TestCase
         $parent->setChildren([$obj1, $obj2]);
 
         $serializer->serialize($parent, JsonLDEncoder::FORMAT);
+    }
+
+    private function getContextWithMapping(string $className) : array
+    {
+        return [
+            JsonLDNormalizer::MAPPPING_KEY => new MappingEndpoint($className, 'http://localhost/blah')
+        ];
     }
 }


### PR DESCRIPTION
This also removes the default namespace configuration option and
removes support for specifing short class names in config

The main motivation for this is to support multiple identical class
names but resolve them correctly